### PR TITLE
fix: Fix parameter name mismatch in constructor

### DIFF
--- a/contracts/src/examples/op-stack/BridgeableMultiOwnableWallet.sol
+++ b/contracts/src/examples/op-stack/BridgeableMultiOwnableWallet.sol
@@ -6,7 +6,7 @@ import {KeystoreBridgeableExt} from "../../extensions/bridging/KeystoreBridgeabl
 import {MultiOwnableWallet} from "./MultiOwnableWallet.sol";
 
 contract BridgeableMultiOwnableWallet is MultiOwnableWallet, KeystoreBridgeableExt {
-    constructor(uint256 masterChainid, address keystoreBridge_)
+    constructor(uint256 masterChainId, address keystoreBridge_)
         MultiOwnableWallet(masterChainId)
         KeystoreBridgeableExt(keystoreBridge_)
     {}


### PR DESCRIPTION
I noticed a typo in the constructor where the parameter `masterChainid` (lowercase `d`) was being passed to `MultiOwnableWallet` as `masterChainId` (uppercase `D`).

This would cause a compilation error due to Solidity's case sensitivity. I've fixed the parameter name to `masterChainId` to ensure consistency and avoid the error.  

This change resolves the issue and ensures the code compiles correctly.